### PR TITLE
Change esClient.create() to esClient.index()

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "async": "^2.0.0-rc.2",
     "chai": "^3.2.0",
     "mocha": "^2.3.3",
-    "elasticsearch": "11.0.1"
+    "elasticsearch": "13.3.1"
   }
 }

--- a/src/elastic-search.js
+++ b/src/elastic-search.js
@@ -64,7 +64,7 @@ module.exports = function sendTestResults(testResultsLog, done) {
     });
 
     async.each(resultsArray, function (data, callback) {
-      esClient.create({
+      esClient.index({
         index: repoConfig.elasticSearchIndex,
         type: 'testLogs',
         body: data


### PR DESCRIPTION
In Elasticsearch 5.5 calling `create()` (equivalent to setting query param `?op_type=create`) fails because `id` is not set.

The logic has now been split: `index()` will "always-add", while `create()` has a "put-if-absent" behaviour. I don't what the intent of the package is, to always have unique test results or to just add them without caring for uniqueness. But the easy fix is just changing `create()` to `index()`, since `create()` would require `id` to be set.

https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-index