### PR TITLE
#9 Send pending result to ElasticSearch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-elk-reporter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/elastic-search.js
+++ b/src/elastic-search.js
@@ -75,6 +75,32 @@ module.exports = function sendTestResults(testResultsLog, done) {
       });
     }
 
+    var pendingTestData = testResultsLog.pending;
+    var pendingTestDataSize = Object.keys(pendingTestData).length;
+    for (var arrayLength = 0; arrayLength < pendingTestDataSize; arrayLength++) {
+
+      let contextValues;
+      if (pendingTestData[arrayLength].context !== undefined) {
+        if (pendingTestData[arrayLength].context.value !== undefined) {
+          contextValues = pendingTestData[arrayLength].context.value;
+        }
+      }
+
+      resultsArray.push({
+        "application_name": repoConfig.applicationName,
+        "et": timestamp,
+        "content":
+          Object.assign({
+            status: "pending",
+            title: pendingTestData[arrayLength].title,
+            fullTitle: pendingTestData[arrayLength].fullTitle,
+            duration: pendingTestData[arrayLength].duration / 1000,
+            err: pendingTestData[arrayLength].err,
+            uuid: pendingTestData[arrayLength].title.match(uuidRegex)
+          }, extraParams, contextValues)
+      });
+    }
+
     var esClient = elasticsearch.Client({
       host: repoConfig.elasticSearchHost,
       log: currentLogLevel,

--- a/test/data/sample-results.js
+++ b/test/data/sample-results.js
@@ -2,9 +2,9 @@ var sampleData = {};
 sampleData.sampleResults = {
   "stats": {
     "suites": 1,
-    "tests": 2,
+    "tests": 3,
     "passes": 1,
-    "pending": 0,
+    "pending": 1,
     "failures": 1,
     "start": "2015-10-23T06:09:40.413Z",
     "end": "2015-10-23T06:09:56.049Z",
@@ -25,6 +25,16 @@ sampleData.sampleResults = {
       "server": "jenkins"
     },
     {
+      "status": "pending",
+      "title": "[uuid:pending-test-00001] Pending Test data from reporter",
+      "fullTitle": "Unit Test - [uuid:pending-test-00001] Pending Test data from reporter",
+      "duration": 8673,
+      "err": {},
+      "platform": "chromeEmulator",
+      "browser": "chrome",
+      "server": "jenkins"
+    },
+    {
       "status": "passed",
       "title": "[uuid:passed-test-00001] Passed Test data from reporter",
       "fullTitle": "Unit Test - [uuid:passed-test-00001] Passed Test data from reporter",
@@ -35,7 +45,20 @@ sampleData.sampleResults = {
       "server": "jenkins"
     }
   ],
-  "pending": [],
+  "pending": [
+     {
+      "status": "pending",
+      "title": "[uuid:pending-test-00001] Pending Test data from reporter",
+      "fullTitle": "Unit Test - [uuid:pending-test-00001] Pending Test data from reporter",
+      "duration": 8673,
+      "err": {
+        "stack": "Sample Failed stack",
+        "message": "Sample failed message"
+      },
+      "platform": "chromeEmulator",
+      "browser": "chrome",
+      "server": "jenkins"
+    }  ],
   "failures": [
     {
       "status": "Failed",


### PR DESCRIPTION
The pending tests are pushed to ElasticSearch as well as the passed and failed tests.  I have updated `sample-results.js` to include a pending test.

I have tested the changes by the following steps:
1. Modify `elk-reporter.js` to the following.  Note that the values for applicationName, elasticSearchHost and elasticSearchIndex are modified.
`
module.exports = {
  applicationName: "test",
  elasticSearchHost: "localhost:9200",
  elasticSearchIndex: "test",
  elasticSearchLogLevel: "trace",
  extraParams: {
    // Any Additional params you want to set
    locale: process.env.LOCALE || 'en-US'
  }
};
`
2. Run the ELK stack on localhost.  (I use the ELK docker image from https://hub.docker.com/r/sebp/elk/.)
3. Run `npm test` on the command line.
4. Open Kibana (http://localhost:5601) on a web browser. Add a new index `test*`.
5. The "Discover" page on Kibana shows the data from `sample-results.js`.

Fixes #9 