### PR TITLE
Add context on failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,26 @@ function ELKReporter(runner) {
   });
 
   runner.on('end', function() {
+    // Add context body from test in tests to failures
+    if (failures.length) {
+      let failuresToIndex = new Map();
+      
+      failures.forEach((failedTest, index) => {
+        if (!failedTest.context) {
+          failuresToIndex.set(failedTest.title, index);
+        }
+      });
+
+      if (failuresToIndex.size) {
+        tests.forEach(test => {
+          if (failuresToIndex.has(test.title)) {
+            const failureIndexToReplace = failuresToIndex.get(test.title);
+            failures[failureIndexToReplace] = test;
+          }
+        });
+      }
+    }
+
     var obj = {
       stats: self.stats,
       tests: tests.map(clean),

--- a/index.js
+++ b/index.js
@@ -41,42 +41,6 @@ function ELKReporter(runner) {
   });
 
   runner.on('end', function() {
-      /*
-      * When Cypress test passes, it provides a test instance to add context using mochawesome/addContext.
-      * But when Cypress test fails, it does not provide test instance to add context.
-      * However it provides test instance when that specific test finishes.
-      * So to add context on test failure, replace test objects in 'failures' array with its equivalent object from 'tests' array.
-      * 
-      * 1. Iterate over failures array. Push failed tests with no context in a map by mapping title to test's index in failures array.
-      * 2. Iterate over tests array, if map has that test title, replace the test object in failures with its equivalent in tests array.
-      *
-      * e.g. tests array - 
-      * [
-      *   Test { title: '[uuid:cy-template-00001], should do first thing', state: 'passed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
-      *   Test { title: '[uuid:cy-template-00002], should do second thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
-      *   Test { title: '[uuid:cy-template-00003], should do third thing', state: 'passed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
-      *   Test { title: '[uuid:cy-template-00004], should do fourth thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....}
-      * ]
-      * 
-      * e.g. failures array - 
-      * Note: it does not have context property on it, but rest of the properties are same as above
-      * [
-      *   {title: '[uuid:cy-template-00002], should do second thing', .....},
-      *   {title: '[uuid:cy-template-00004], should do fourth thing', .....},
-      * ]
-      * 
-      * e.g. failuresToIndex map -
-      * { 
-      *  '[uuid:cy-template-00002], should do second thing' => 2,
-      *  '[uuid:cy-template-00004], should do fourth thing' => 3 
-      * }
-      * 
-      * e.g. after replacing test objects, failures array -
-      * { 
-      *   Test { title: '[uuid:cy-template-00002], should do second thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
-      *   Test { title: '[uuid:cy-template-00004], should do fourth thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....}
-      * }
-      */
     if (failures.length) {
      let failuresToIndex = new Map();
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function ELKReporter(runner) {
 
   runner.on('end', function() {
       /*
-      * When Cypress passes, it provides a test instance to add context using mochawesome/addContext.
+      * When Cypress test passes, it provides a test instance to add context using mochawesome/addContext.
       * But when Cypress test fails, it does not provide test instance to add context.
       * However it provides test instance when that specific test finishes.
       * So to add context on test failure, replace test objects in 'failures' array with its equivalent object from 'tests' array.

--- a/index.js
+++ b/index.js
@@ -44,7 +44,14 @@ function ELKReporter(runner) {
     // Add context body from test in tests to failures
     if (failures.length) {
       let failuresToIndex = new Map();
-      
+
+      /*
+      * Map failed test to its index in failures e.g. failuresToIndex will look like this 
+      * { 
+      *  '[uuid:cy-template-00002], should do first thing' => 2 
+      *  '[uuid:cy-template-00005], should do second thing' => 3 
+      * }
+      */
       failures.forEach((failedTest, index) => {
         if (!failedTest.context) {
           failuresToIndex.set(failedTest.title, index);
@@ -54,8 +61,8 @@ function ELKReporter(runner) {
       if (failuresToIndex.size) {
         tests.forEach(test => {
           if (failuresToIndex.has(test.title)) {
-            const failureIndexToReplace = failuresToIndex.get(test.title);
-            failures[failureIndexToReplace] = test;
+            const indexToReplace = failuresToIndex.get(test.title);
+            failures[indexToReplace] = test;
           }
         });
       }


### PR DESCRIPTION
### Description

When Cypress test passes, it provides a test instance to add context using mochawesome/addContext.
But when Cypress test fails, it does not provide test instance to add context.
However it provides test instance when that specific test finishes.
So to add context on test failure, replace test objects in 'failures' array with its equivalent object from 'tests' array.
1. Iterate over failures array. Push failed tests with no context in a map by mapping title to test's index in failures array.
2. Iterate over tests array, if map has that test title, replace the test object in failures with its equivalent in tests array.

```
e.g. tests array - 

[
  Test { title: '[uuid:cy-template-00001], should do first thing', state: 'passed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
  Test { title: '[uuid:cy-template-00002], should do second thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
  Test { title: '[uuid:cy-template-00003], should do third thing', state: 'passed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
  Test { title: '[uuid:cy-template-00004], should do fourth thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....}
]
```

```
e.g. failures array -

[
  {title: '[uuid:cy-template-00002], should do second thing', .....},
  {title: '[uuid:cy-template-00004], should do fourth thing', .....},
]
```
Note: In Failures array above, it **DOES NOT** have context property on it, but rest of the properties are same as tests array.


```
e.g. failuresToIndex map -
{ 
 '[uuid:cy-template-00002], should do second thing' => 2,
 '[uuid:cy-template-00004], should do fourth thing' => 3 
}
```

```
e.g. after replacing test objects, failures array -
{ 
  Test { title: '[uuid:cy-template-00002], should do second thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....},
  Test { title: '[uuid:cy-template-00004], should do fourth thing', state: 'failed', context: {title: 'some string', value: {shopperId: '1111'}}, .....}
}
```

### Screenshots

1. Pass scenario - 

![image](https://user-images.githubusercontent.com/13083115/93419548-f8541e80-f861-11ea-9e98-a1830f2aecff.png)

2. Failure scenario

![image](https://user-images.githubusercontent.com/13083115/93419572-06a23a80-f862-11ea-87a6-ba6cbf8298a7.png)
