### PR TITLE
Add required properties to prevAttempts object

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,22 +95,55 @@ function ELKReporter(runner) {
  */
 function addRetryFailures(failures, passes) {
   let prevAttempts = [];
-  
-  failures.forEach(test => {
-    if (test.prevAttempts && test.prevAttempts.length) {
-      prevAttempts.push(...test.prevAttempts);
+
+  // when test fails in all attempts
+  failures.forEach((failure) => {
+    if (failure.prevAttempts && failure.prevAttempts.length) {
+        failure.prevAttempts.forEach(failedTestAttempt => {
+          if (!failedTestAttempt.fullTitle) {
+            console.log('Sending from failures')
+            addRequiredProps(failedTestAttempt, failure, prevAttempts)
+          } else {
+            prevAttempts.push(failedTestAttempt);
+          }
+        })
     }
   });
   
-  passes.forEach(test => {
-    if (test.prevAttempts && test.prevAttempts.length) {
-      prevAttempts.push(...test.prevAttempts);
+  // when test passes but has failed attempts
+  passes.forEach(passedTest => {
+    if (passedTest.prevAttempts && passedTest.prevAttempts.length) {
+      passedTest.prevAttempts.forEach(failedTestAttempt => {
+        if (!failedTestAttempt.fullTitle) {
+          console.log('Sending from passes')
+          addRequiredProps(failedTestAttempt, passedTest, prevAttempts)
+        } else {
+          prevAttempts.push(failedTestAttempt);
+        }
+      })
     }
   });
   
   if (prevAttempts.length) {
     failures.push(...prevAttempts);
   }
+}
+
+/**
+ * Adds required properties from parent test instance to previously failed attempt
+ * 
+ * @param {Object} testAttempt - test instance from prevAttempts
+ * @param {Object} parentTestInstance - parent test instance with property prevAttempts
+ * @param {Array} prevAttempts - array to insert all previous failures
+ */
+function addRequiredProps(failedAttempt, parentTestInstance, prevAttempts) {
+  failedAttempt.duration = parentTestInstance.duration;
+  failedAttempt.parent = parentTestInstance.parent;
+  failedAttempt.title = parentTestInstance.title;
+  failedAttempt.context = parentTestInstance.context;
+  failedAttempt.fullTitle = parentTestInstance.fullTitle;
+  failedAttempt.titlePath = parentTestInstance.titlePath;
+  prevAttempts.push(failedAttempt);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -101,7 +101,6 @@ function addRetryFailures(failures, passes) {
     if (failure.prevAttempts && failure.prevAttempts.length) {
         failure.prevAttempts.forEach(failedTestAttempt => {
           if (!failedTestAttempt.fullTitle) {
-            console.log('Sending from failures')
             addRequiredProps(failedTestAttempt, failure, prevAttempts)
           } else {
             prevAttempts.push(failedTestAttempt);
@@ -115,7 +114,6 @@ function addRetryFailures(failures, passes) {
     if (passedTest.prevAttempts && passedTest.prevAttempts.length) {
       passedTest.prevAttempts.forEach(failedTestAttempt => {
         if (!failedTestAttempt.fullTitle) {
-          console.log('Sending from passes')
           addRequiredProps(failedTestAttempt, passedTest, prevAttempts)
         } else {
           prevAttempts.push(failedTestAttempt);
@@ -137,11 +135,11 @@ function addRetryFailures(failures, passes) {
  * @param {Array} prevAttempts - array to insert all previous failures
  */
 function addRequiredProps(failedAttempt, parentTestInstance, prevAttempts) {
+  failedAttempt.context = parentTestInstance.context;
   failedAttempt.duration = parentTestInstance.duration;
+  failedAttempt.fullTitle = parentTestInstance.fullTitle;
   failedAttempt.parent = parentTestInstance.parent;
   failedAttempt.title = parentTestInstance.title;
-  failedAttempt.context = parentTestInstance.context;
-  failedAttempt.fullTitle = parentTestInstance.fullTitle;
   failedAttempt.titlePath = parentTestInstance.titlePath;
   prevAttempts.push(failedAttempt);
 }

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function ELKReporter(runner) {
     }
 
     // add failed retry attempts to failures array
+    
     addRetryFailures(failures, passes);
 
     var obj = {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ function ELKReporter(runner) {
     }
 
     // add failed retry attempts to failures array
-    
     addRetryFailures(failures, passes);
 
     var obj = {

--- a/index.js
+++ b/index.js
@@ -136,7 +136,6 @@ function addRetryFailures(failures, passes) {
  */
 function addRequiredProps(failedAttempt, parentTestInstance, prevAttempts) {
   failedAttempt.context = parentTestInstance.context;
-  failedAttempt.duration = parentTestInstance.duration;
   failedAttempt.fullTitle = parentTestInstance.fullTitle;
   failedAttempt.parent = parentTestInstance.parent;
   failedAttempt.title = parentTestInstance.title;

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function addRetryFailures(failures, passes) {
   let prevAttempts = [];
 
   // when test fails in all attempts
-  failures.forEach((failure) => {
+  failures.forEach(failure => {
     if (failure.prevAttempts && failure.prevAttempts.length) {
         failure.prevAttempts.forEach(failedTestAttempt => {
           if (!failedTestAttempt.fullTitle) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-elk-reporter",
-  "version": "2.5.0",
+  "version": "2.6.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-elk-reporter",
-  "version": "2.5.0",
+  "version": "2.6.0-beta1",
   "description": "Reporter for pushing mocha test results data to ELK",
   "main": "index.js",
   "scripts": {

--- a/test/data/passed-failed-tests.js
+++ b/test/data/passed-failed-tests.js
@@ -2,7 +2,25 @@ const passedTests = [
   {
     status: 'passed',
     title: '[uuid:template-test-00001] Passed Test data from reporter',
-    fullTitle: 'Unit Test - [uuid:template-test-00001] Passed Test data from reporter',
+    fullTitle: function() {
+      return this.titlePath().join(' ');
+    },
+    titlePath: function() {
+      return this.parent.titlePath().concat([this.title]);
+    },
+    parent : {
+      title: 'Describe block title',
+      titlePath: function() {
+        var result = [];
+        if (this.parent) {
+          result = result.concat(this.parent.titlePath());
+        }
+        if (!this.root) {
+          result.push(this.title);
+        }
+        return result;
+      }
+    },
     duration: 8673,
     err: {},
     platform: 'chromeEmulator',
@@ -11,9 +29,6 @@ const passedTests = [
     prevAttempts: [
       {
         status: 'Failed',
-        title: '[uuid:template-test-00001] Failed Test data from reporter',
-        fullTitle: 'Unit Test - [uuid:template-test-00001] Failed Test data from reporter',
-        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'
@@ -24,9 +39,6 @@ const passedTests = [
       },
       {
         status: 'Failed',
-        title: '[uuid:template-test-00001] Failed Test data from reporter',
-        fullTitle: 'Unit Test - [uuid:template-test-00001] Failed Test data from reporter',
-        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'
@@ -43,7 +55,25 @@ const failedTests = [
   {
     status: 'Failed',
     title: '[uuid:template-test-00002] Failed Test data from reporter',
-    fullTitle: 'Unit Test - [uuid:template-test-00002] Failed Test data from reporter',
+    fullTitle: function() {
+      return this.titlePath().join(' ');
+    },
+    titlePath: function() {
+      return this.parent.titlePath().concat([this.title]);
+    },
+    parent : {
+      title: 'Describe block title',
+      titlePath: function() {
+        var result = [];
+        if (this.parent) {
+          result = result.concat(this.parent.titlePath());
+        }
+        if (!this.root) {
+          result.push(this.title);
+        }
+        return result;
+      }
+    },
     duration: 8673,
     err: {
       stack: 'Sample Failed stack',
@@ -55,9 +85,6 @@ const failedTests = [
     prevAttempts: [
       {
         status: 'Failed',
-        title: '[uuid:template-test-00002] Failed Test data from reporter',
-        fullTitle: 'Unit Test - [uuid:template-test-00002] Failed Test data from reporter',
-        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'
@@ -68,9 +95,6 @@ const failedTests = [
       },
       {
         status: 'Failed',
-        title: '[uuid:template-test-00002] Failed Test data from reporter',
-        fullTitle: 'Unit Test - [uuid:template-test-00002] Failed Test data from reporter',
-        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'

--- a/test/data/passed-failed-tests.js
+++ b/test/data/passed-failed-tests.js
@@ -2,25 +2,7 @@ const passedTests = [
   {
     status: 'passed',
     title: '[uuid:template-test-00001] Passed Test data from reporter',
-    fullTitle: function() {
-      return this.titlePath().join(' ');
-    },
-    titlePath: function() {
-      return this.parent.titlePath().concat([this.title]);
-    },
-    parent : {
-      title: 'Describe block title',
-      titlePath: function() {
-        var result = [];
-        if (this.parent) {
-          result = result.concat(this.parent.titlePath());
-        }
-        if (!this.root) {
-          result.push(this.title);
-        }
-        return result;
-      }
-    },
+    fullTitle: 'Unit Test - [uuid:template-test-00001] Passed Test data from reporter',
     duration: 8673,
     err: {},
     platform: 'chromeEmulator',
@@ -29,6 +11,9 @@ const passedTests = [
     prevAttempts: [
       {
         status: 'Failed',
+        title: '[uuid:template-test-00001] Failed Test data from reporter',
+        fullTitle: 'Unit Test - [uuid:template-test-00001] Failed Test data from reporter',
+        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'
@@ -39,6 +24,9 @@ const passedTests = [
       },
       {
         status: 'Failed',
+        title: '[uuid:template-test-00001] Failed Test data from reporter',
+        fullTitle: 'Unit Test - [uuid:template-test-00001] Failed Test data from reporter',
+        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'
@@ -55,25 +43,7 @@ const failedTests = [
   {
     status: 'Failed',
     title: '[uuid:template-test-00002] Failed Test data from reporter',
-    fullTitle: function() {
-      return this.titlePath().join(' ');
-    },
-    titlePath: function() {
-      return this.parent.titlePath().concat([this.title]);
-    },
-    parent : {
-      title: 'Describe block title',
-      titlePath: function() {
-        var result = [];
-        if (this.parent) {
-          result = result.concat(this.parent.titlePath());
-        }
-        if (!this.root) {
-          result.push(this.title);
-        }
-        return result;
-      }
-    },
+    fullTitle: 'Unit Test - [uuid:template-test-00002] Failed Test data from reporter',
     duration: 8673,
     err: {
       stack: 'Sample Failed stack',
@@ -85,6 +55,9 @@ const failedTests = [
     prevAttempts: [
       {
         status: 'Failed',
+        title: '[uuid:template-test-00002] Failed Test data from reporter',
+        fullTitle: 'Unit Test - [uuid:template-test-00002] Failed Test data from reporter',
+        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'
@@ -95,6 +68,9 @@ const failedTests = [
       },
       {
         status: 'Failed',
+        title: '[uuid:template-test-00002] Failed Test data from reporter',
+        fullTitle: 'Unit Test - [uuid:template-test-00002] Failed Test data from reporter',
+        duration: 8673,
         err: {
           stack: 'Sample Failed stack',
           message: 'Sample failed message'

--- a/test/data/passed-failed-tests.js
+++ b/test/data/passed-failed-tests.js
@@ -87,7 +87,6 @@ const failedTestWithMissingProps = [
   {
     status: 'Failed',
     title: '[uuid:template-test-00003] Failed Test data from reporter',
-    // fullTitle: 'Unit Test - [uuid:template-test-00003] Failed Test data from reporter',
     fullTitle: function() {
       return this.titlePath().join(' ');
     },

--- a/test/data/passed-failed-tests.js
+++ b/test/data/passed-failed-tests.js
@@ -83,7 +83,127 @@ const failedTests = [
   }
 ];
 
+const failedTestWithMissingProps = [
+  {
+    status: 'Failed',
+    title: '[uuid:template-test-00003] Failed Test data from reporter',
+    // fullTitle: 'Unit Test - [uuid:template-test-00003] Failed Test data from reporter',
+    fullTitle: function() {
+      return this.titlePath().join(' ');
+    },
+    titlePath: function() {
+      return this.parent.titlePath().concat([this.title]);
+    },
+    duration: 8673,
+    parent : {
+      title: 'Describe block title',
+      titlePath: function() {
+        var result = [];
+        if (this.parent) {
+          result = result.concat(this.parent.titlePath());
+        }
+        if (!this.root) {
+          result.push(this.title);
+        }
+        return result;
+      }
+    },
+    err: {
+      stack: 'Sample Failed stack',
+      message: 'Sample failed message'
+    },
+    platform: 'chromeEmulator',
+    browser: 'chrome',
+    server: 'jenkins',
+    context: {
+      title: '[uuid:template-test-00003] Failed Test data from reporter',
+      value: {
+        shopper: 'test shopper id'
+      }
+    },
+    prevAttempts: [
+      {
+        status: 'Failed',
+        err: {
+          stack: 'Sample Failed stack',
+          message: 'Sample failed message'
+        },
+        platform: 'chromeEmulator',
+        browser: 'chrome',
+        server: 'jenkins'
+      },
+      {
+        status: 'Failed',
+        err: {
+          stack: 'Sample Failed stack',
+          message: 'Sample failed message'
+        },
+        platform: 'chromeEmulator',
+        browser: 'chrome',
+        server: 'jenkins'
+      }
+    ]
+  }
+];
+
+const passedTestsWithMissingProps = [
+  {
+    status: 'passed',
+    title: '[uuid:template-test-00001] Passed Test data from reporter',
+    fullTitle: 'Unit Test - [uuid:template-test-00001] Passed Test data from reporter',
+    duration: 8673,
+    err: {},
+    platform: 'chromeEmulator',
+    browser: 'chrome',
+    server: 'jenkins',
+    fullTitle: function() {
+      return this.titlePath().join(' ');
+    },
+    titlePath: function() {
+      return this.parent.titlePath().concat([this.title]);
+    },
+    parent : {
+      title: 'Describe block title',
+      titlePath: function() {
+        var result = [];
+        if (this.parent) {
+          result = result.concat(this.parent.titlePath());
+        }
+        if (!this.root) {
+          result.push(this.title);
+        }
+        return result;
+      }
+    },
+    prevAttempts: [
+      {
+        status: 'Failed',
+        err: {
+          stack: 'Sample Failed stack',
+          message: 'Sample failed message'
+        },
+        platform: 'chromeEmulator',
+        browser: 'chrome',
+        server: 'jenkins'
+      },
+      {
+        status: 'Failed',
+        err: {
+          stack: 'Sample Failed stack',
+          message: 'Sample failed message'
+        },
+        platform: 'chromeEmulator',
+        browser: 'chrome',
+        server: 'jenkins'
+      }
+    ]
+  }
+];
+
+
 module.exports = {
   passedTests,
-  failedTests
+  failedTests,
+  failedTestWithMissingProps,
+  passedTestsWithMissingProps
 };

--- a/test/elk-reporter-spec.js
+++ b/test/elk-reporter-spec.js
@@ -55,7 +55,6 @@ describe('ELK Reporter Tests: ', () => {
       assert(failures.length === 5);
       assert(passes.length === 1);
       assert(failures[0].context !== undefined);
-      assert(failures[1].duration !== undefined);
       assert(failures[2].fullTitle !== undefined);
       assert(failures[3].parent !== undefined);
       assert(failures[4].title !== undefined);

--- a/test/elk-reporter-spec.js
+++ b/test/elk-reporter-spec.js
@@ -2,7 +2,12 @@
 
 const assert = require('assert');
 const rewire = require('rewire');
-const {passedTests, failedTests} = require('./data/passed-failed-tests');
+const {
+  passedTests, 
+  failedTests,
+  failedTestWithMissingProps,
+  passedTestsWithMissingProps
+} = require('./data/passed-failed-tests');
 const elkReporter = rewire('./../index.js');
 
 describe('ELK Reporter Tests: ', () => {
@@ -42,5 +47,18 @@ describe('ELK Reporter Tests: ', () => {
       assert(failures.length === 0);
       assert(passes.length === 1);
     });
+
+    it('should add missing properties', () => {
+      passes = [...passedTestsWithMissingProps];
+      failures = [...failedTestWithMissingProps];
+      addRetryFailures(failures, passes);
+      assert(failures.length === 5);
+      assert(passes.length === 1);
+      assert(failures[0].context !== undefined);
+      assert(failures[1].duration !== undefined);
+      assert(failures[2].fullTitle !== undefined);
+      assert(failures[3].parent !== undefined);
+      assert(failures[4].title !== undefined);
+    })
   })
 });


### PR DESCRIPTION
### Description 
Cypress version `6.2.1` or greater does not forward some of the properties e.g. `duration, title, fullTitle(), context etc` that `mocha-elk-reporter` needs. It throws an error saying - 

`TypeError: test.fullTitle is not a function`

When Cypress version < `6.2.1` - 

```
{
  status: 'passed',
  title: '[uuid:template-test-00001] Passed Test data from reporter',
  fullTitle: 'Unit Test - [uuid:template-test-00001] Passed Test data from reporter',
  duration: 8673,
  err: {},
  platform: 'chromeEmulator',
  browser: 'chrome',
  server: 'jenkins',
  prevAttempts: [
    {
      status: 'Failed',
      title: '[uuid:template-test-00001] Failed Test data from reporter',
      fullTitle: 'Unit Test - [uuid:template-test-00001] Failed Test data from reporter',
      duration: 8673,
      err: {
        stack: 'Sample Failed stack',
        message: 'Sample failed message'
      },
      platform: 'chromeEmulator',
      browser: 'chrome',
      server: 'jenkins'
    },
    {
      status: 'Failed',
      title: '[uuid:template-test-00001] Failed Test data from reporter',
      fullTitle: 'Unit Test - [uuid:template-test-00001] Failed Test data from reporter',
      duration: 8673,
      err: {
        stack: 'Sample Failed stack',
        message: 'Sample failed message'
      },
      platform: 'chromeEmulator',
      browser: 'chrome',
      server: 'jenkins'
    }
  ]
}
```

When Cypress version > `6.2.1` - 

```
{
    status: 'passed',
    title: '[uuid:template-test-00001] Passed Test data from reporter',
    fullTitle: 'Unit Test - [uuid:template-test-00001] Passed Test data from reporter',
    duration: 8673,
    err: {},
    platform: 'chromeEmulator',
    browser: 'chrome',
    server: 'jenkins',
    fullTitle: function() {
      return this.titlePath().join(' ');
    },
    titlePath: function() {
      return this.parent.titlePath().concat([this.title]);
    },
    parent : {
      title: 'Describe block title',
      titlePath: function() {
        var result = [];
        if (this.parent) {
          result = result.concat(this.parent.titlePath());
        }
        if (!this.root) {
          result.push(this.title);
        }
        return result;
      }
    },
    prevAttempts: [
      {
        status: 'Failed',
        err: {
          stack: 'Sample Failed stack',
          message: 'Sample failed message'
        },
        platform: 'chromeEmulator',
        browser: 'chrome',
        server: 'jenkins'
      },
      {
        status: 'Failed',
        err: {
          stack: 'Sample Failed stack',
          message: 'Sample failed message'
        },
        platform: 'chromeEmulator',
        browser: 'chrome',
        server: 'jenkins'
      }
    ]
  }
```

### Solution
With this PR, I'm copying those missing properties from the parent test instance.













