### PR TITLE
Move auth from URL to client option

### DIFF
--- a/src/elastic-search.js
+++ b/src/elastic-search.js
@@ -116,14 +116,17 @@ module.exports = function sendTestResults(testResultsLog, done) {
     }
 
     var hostname = repoConfig.elasticSearchHost
+    var auth = null
     if (!!elasticsearchUsername === true || !!elasticsearchPassword === true) {
-      auth = `${elasticsearchUsername}:${elasticsearchPassword}@`
-      // Override any username:password in the elasticSearchHost param
-      hostname = `${auth}${hostname}`
+      auth = {
+        username: elasticsearchUsername,
+        password: elasticsearchPassword
+      }
     }
 
     var esClient = new elasticsearch.Client({
       node: hostname,
+      auth: auth,
       log: currentLogLevel,
       requestTimeout: currentTimeout
     });


### PR DESCRIPTION
Hi @mpahuja !  Long time 👋🏻  Submitting this as a change so we can move the auth bits from the URL into the specified client option according to the [docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.17/basic-config.html), conditionally if they're defined (let me know if there's a better way to go about this...).  This will allow us to specify protocol (https) as part of the url / host param now to enable SSL.  It should be completely backwards compatible, but famous last words :-p